### PR TITLE
Fixed a NPE while logging the cause of an exception with no cause

### DIFF
--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/abstracts/AbstractTask.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/abstracts/AbstractTask.java
@@ -200,8 +200,11 @@ public abstract class AbstractTask implements Callable<NFVMessage>, ApplicationE
   private void genericExceptionHandling(Exception e) {
     e.printStackTrace();
     log.debug("The exception is: " + e.getClass().getName());
-    log.debug("The cause is: " + e.getCause().getClass().getName());
-    e.printStackTrace();
+
+    if (e.getCause() != null) {
+      log.debug("The cause is: " + e.getCause().getClass().getName());
+    }
+
     VnfmSender vnfmSender;
     try {
       vnfmSender =


### PR DESCRIPTION
A NullPointerException was raised by `log.debug("The cause is: " + e.getCause().getClass().getName());` when logging Exception that had no cause, stopping the NFVO from sending `e` back to the VNFM.