### PR TITLE
Fix: empty list of VDU-VIMInstance when deploying

### DIFF
--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
@@ -214,7 +214,11 @@ public class NetworkServiceRecordManagement
     networkServiceDescriptor.setProjectId(projectId);
     //    nsdUtils.fetchVimInstances(networkServiceDescriptor, projectId);
     DeployNSRBody body = new DeployNSRBody();
-    body.setVduVimInstances(vduVimInstances);
+    if (vduVimInstances == null) {
+      body.setVduVimInstances(new HashMap<String, Collection<String>>());
+    } else {
+      body.setVduVimInstances(vduVimInstances);
+    }
     if (configurations == null) {
       body.setConfigurations(new HashMap());
     } else {
@@ -895,7 +899,8 @@ public class NetworkServiceRecordManagement
 
         if (body == null
             || body.getVduVimInstances() == null
-            || body.getVduVimInstances().get(vdu.getName()) == null) {
+            || body.getVduVimInstances().get(vdu.getName()) == null
+            || body.getVduVimInstances().get(vdu.getName()).isEmpty()) {
           if (vdu.getVimInstanceName() == null) {
             throw new MissingParameterException(
                 "No VimInstances specified for vdu: " + vdu.getName());


### PR DESCRIPTION
In case of empty VIMInstance list passed while deploying, it should be handled as not defined. Only if VIM Instances are passed for a particular VDU, it should replace the ones in the descriptor. 