### PR TITLE
Fix: another fix for empty list of VDU-VIMInstance while deploying

### DIFF
--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
@@ -996,7 +996,8 @@ public class NetworkServiceRecordManagement
           Collection<String> instanceNames;
           if (body == null
               || body.getVduVimInstances() == null
-              || body.getVduVimInstances().get(vdu.getName()) == null) {
+              || body.getVduVimInstances().get(vdu.getName()) == null
+              || body.getVduVimInstances().get(vdu.getName()).isEmpty()) {
             if (vdu.getVimInstanceName() == null) {
               throw new MissingParameterException(
                   "No VimInstances specified for vdu: " + vdu.getName());


### PR DESCRIPTION
another fix for empty list of VDU-VIMInstance while deploying