### PR TITLE
Fix: fix VnfmManager for empty list of VDU-VIMInstance while deploying

### DIFF
--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/VnfmManager.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/VnfmManager.java
@@ -301,7 +301,8 @@ public class VnfmManager
           Collection<String> instanceNames;
           if (body == null
               || body.getVduVimInstances() == null
-              || body.getVduVimInstances().get(vdu.getName()) == null) {
+              || body.getVduVimInstances().get(vdu.getName()) == null
+              || body.getVduVimInstances().get(vdu.getName()).isEmpty()) {
             instanceNames = vdu.getVimInstanceName();
           } else {
             instanceNames = body.getVduVimInstances().get(vdu.getName());


### PR DESCRIPTION
fix VnfmManager for empty list of VDU-VIMInstance while deploying