### PR TITLE
Fix: remove mysql SSL warning

### DIFF
--- a/etc/openbaton.properties
+++ b/etc/openbaton.properties
@@ -113,7 +113,7 @@ spring.datasource.password=changeme
 #       org.hsqldb.jdbc.JDBCDriver
 #       org.hibernate.dialect.HSQLDialect
 # JDBC configurations' values for MYSQL:
-#       jdbc:mysql://localhost:3306/openbaton
+#       jdbc:mysql://localhost:3306/openbaton?useSSL=false
 #       com.mysql.jdbc.Driver
 #       org.hibernate.dialect.MySQLDialect
 #


### PR DESCRIPTION
Disabling SSL for mysql (as suggested in the warning) actually removes this warning.
resolves #107 