### PR TITLE
fix 1 lgtm.com alert

### DIFF
--- a/security/src/main/java/org/openbaton/nfvo/security/authorization/UserManagement.java
+++ b/security/src/main/java/org/openbaton/nfvo/security/authorization/UserManagement.java
@@ -219,7 +219,7 @@ public class UserManagement implements org.openbaton.nfvo.security.interfaces.Us
       if (role.getProject() == null || role.getProject().equals("")) {
         throw new BadRequestException("Project must be provided");
       }
-      if (role.getRole() == null || role.getRole().equals("")) {
+      if (role.getRole() == null) {
         throw new BadRequestException("Role must be provided");
       }
       if (!role.getProject().equals("*")) {


### PR DESCRIPTION
Hi,
Just wanted to quickly fix this alert on enum comparison flagged up on lgtm.com - I hope it helps.

`Role` is an enum so a string comparison would need to use `.name().equals(string)` but in this case it does not seem necessary if the purpose is just to check existence.

A total of 185 alerts have been flagged up by lgtm.com:
https://lgtm.com/projects/g/openbaton/NFVO

You can enable pull request integration for fully automated PR reviews that will flag these in the future so they don't get past code review :)