### PR TITLE
Issue-#147 Configuration paramters 

### DIFF
--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
@@ -182,7 +182,6 @@ public class NetworkServiceRecordManagement
           BadRequestException {
     log.info("Looking for NetworkServiceDescriptor with id: " + idNsd);
     NetworkServiceDescriptor networkServiceDescriptor = nsdRepository.findFirstById(idNsd);
-    log.info(networkServiceDescriptor.getId());
 
     if (networkServiceDescriptor == null) {
       throw new NotFoundException("NSD with id " + idNsd + " was not found");

--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
 import org.openbaton.catalogue.api.DeployNSRBody;
 import org.openbaton.catalogue.mano.common.DeploymentFlavour;
 import org.openbaton.catalogue.mano.common.Ip;
@@ -159,6 +160,7 @@ public class NetworkServiceRecordManagement
 
   @Autowired private KeyRepository keyRepository;
   @Autowired private VnfPackageRepository vnfPackageRepository;
+  @Autowired private EntityManager entityManager;
 
   @PostConstruct
   private void init() {
@@ -180,6 +182,8 @@ public class NetworkServiceRecordManagement
           BadRequestException {
     log.info("Looking for NetworkServiceDescriptor with id: " + idNsd);
     NetworkServiceDescriptor networkServiceDescriptor = nsdRepository.findFirstById(idNsd);
+    log.info(networkServiceDescriptor.getId());
+
     if (networkServiceDescriptor == null) {
       throw new NotFoundException("NSD with id " + idNsd + " was not found");
     }
@@ -187,6 +191,11 @@ public class NetworkServiceRecordManagement
       throw new UnauthorizedUserException(
           "NSD not under the project chosen, are you trying to hack us? Just kidding, it's a bug :)");
     }
+    // Detach instance of NSD to stop persistance
+    if (networkServiceDescriptor.getId() != null) {
+      entityManager.detach(networkServiceDescriptor);
+    }
+
     DeployNSRBody body = new DeployNSRBody();
     body.setVduVimInstances(vduVimInstances);
     if (configurations == null) {

--- a/openbaton-libs/catalogue/src/main/java/org/openbaton/catalogue/nfvo/RequiresParameters.java
+++ b/openbaton-libs/catalogue/src/main/java/org/openbaton/catalogue/nfvo/RequiresParameters.java
@@ -30,7 +30,7 @@ public class RequiresParameters {
   @Version private int version;
 
   @Column
-  @ElementCollection(targetClass = String.class)
+  @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)
   private Set<String> parameters;
 
   @PrePersist


### PR DESCRIPTION
When the NSD is accessed using the repository, the Entity returned is in persistant state, so to prevent it from being updated it has to be detached from the session. 
This fixes the problem of updating the NSD in the checkConfigurations function. 

However I found that a problem occures when we have lazily fetched parts of the NSD. Because the NSD is detached it can no longer retrieve the data of a parameter that has a fetch type LAZY. Therefore all parameters with fetch type LAZY part of the NSD and it's children may cause an Exception.

The commit:
https://github.com/openbaton/NFVO/pull/162/commits/2ea27ab95afc8b7c29fbadd9588d8747a559e1bb
changes the requires parameter to EAGER. In the future if we add parameters that have to be fetched lazily, we will need to find another solution. 