### PR TITLE
Fix: set db connectors for upgrade from 3.2.0

### DIFF
--- a/gradle/gradle/scripts/debian/postinst
+++ b/gradle/gradle/scripts/debian/postinst
@@ -197,6 +197,10 @@ configure_for_upgrade () {
     log_success_msg "Upgrading Open Baton ${OPENBATON_COMPONENT_NAME_FANCY} installation .."
 }
 
+fix_db_connectors_used () {
+    sed -i "s|spring.datasource.driver-class-name\s*=\s*com.mysql.jdbc.Driver|spring.datasource.driver-class-name=org.mariadb.jdbc.Driver|g" /etc/openbaton/openbaton-${OPENBATON_COMPONENT_NAME}.properties
+}
+
 start_component () {
     # Allow the use of the .deb package to install Open Baton with Docker (the Docker file developer need to manage the starting of the NFVO in the Docker file) 
     if [ "${OPENBATON_COMPONENT_AUTOSTART}" = "true" ]; then
@@ -223,6 +227,7 @@ case "${1}" in
             configure_new_installation
         else # upgrade (during upgrade the postinst file is invoked as: 'postinst configure <old_version_number>')
             configure_for_upgrade
+            fix_db_connectors_used
         fi 
         ;;
 


### PR DESCRIPTION
        When upgrading from 3.2.0, if the persistence was enabled, the
        mysql connector value needs to be set to the 'mariadb' one