### PR TITLE
Fix: Deadlock when deploying many NSs in parallel

### DIFF
--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 import org.apache.commons.net.util.SubnetUtils;
 import org.openbaton.catalogue.api.DeployNSRBody;
@@ -117,8 +116,7 @@ public class NetworkServiceRecordManagement
     implements org.openbaton.nfvo.core.interfaces.NetworkServiceRecordManagement {
 
   private final Logger log = LoggerFactory.getLogger(this.getClass());
-  private ThreadPoolTaskExecutor asyncExecutor;
-
+  @Autowired private ThreadPoolTaskExecutor asyncExecutor;
   @Autowired private EventDispatcher publisher;
   @Autowired private NetworkServiceRecordRepository nsrRepository;
   @Autowired private NetworkServiceDescriptorRepository nsdRepository;
@@ -156,19 +154,6 @@ public class NetworkServiceRecordManagement
   @Autowired private KeyRepository keyRepository;
   @Autowired private VnfPackageRepository vnfPackageRepository;
   @Autowired private VimManagement vimManagement;
-
-  @PostConstruct
-  private void init() {
-    if (removeAfterTimeout) {
-      asyncExecutor = new ThreadPoolTaskExecutor();
-      asyncExecutor.setThreadNamePrefix("OpenbatonTask-");
-      asyncExecutor.setMaxPoolSize(30);
-      asyncExecutor.setCorePoolSize(5);
-      asyncExecutor.setQueueCapacity(0);
-      asyncExecutor.setKeepAliveSeconds(20);
-      asyncExecutor.initialize();
-    }
-  }
 
   @Override
   public NetworkServiceRecord onboard(

--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/VimManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/VimManagement.java
@@ -17,6 +17,19 @@
 
 package org.openbaton.nfvo.core.api;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.openbaton.catalogue.mano.common.DeploymentFlavour;
 import org.openbaton.catalogue.mano.descriptor.VirtualDeploymentUnit;
 import org.openbaton.catalogue.mano.descriptor.VirtualNetworkFunctionDescriptor;
@@ -48,20 +61,6 @@ import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
-
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /** Created by lto on 13/05/15. */
 @Service
@@ -348,7 +347,7 @@ public class VimManagement implements org.openbaton.nfvo.core.interfaces.VimMana
         URL authUrl;
         try {
           authUrl = new URL(vimInstance.getAuthUrl());
-        } catch (MalformedURLException ignored){
+        } catch (MalformedURLException ignored) {
           return;
         }
         log.trace(

--- a/etc/openbaton.properties
+++ b/etc/openbaton.properties
@@ -71,10 +71,12 @@ nfvo.vim.delete.check.vnfr=true
 
 # Thread pool executor configuration
 # for info see http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.html
-nfvo.vmanager.executor.corepoolsize=20
+# We suggest to keep the queuecapacity and maxpoolsize values unless you have a good reason to change them.
+nfvo.vmanager.executor.corepoolsize=30
 nfvo.vmanager.executor.keepalive=30
-nfvo.vmanager.executor.maxpoolsize=30
-nfvo.vmanager.executor.queuecapacity=500
+nfvo.vmanager.executor.queuecapacity=0
+# default is Integer.MAX_VALUE
+# nfvo.vmanager.executor.maxpoolsize=100
 
 nfvo.vnfd.cascade.delete=false
 vnfd.vnfp.cascade.delete=true

--- a/main/src/main/java/org/openbaton/nfvo/system/AsyncExecutorConfig.java
+++ b/main/src/main/java/org/openbaton/nfvo/system/AsyncExecutorConfig.java
@@ -1,6 +1,8 @@
 package org.openbaton.nfvo.system;
 
 import java.util.concurrent.Executor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -15,13 +17,61 @@ The Executor, which will be used, can be configured here.
 @EnableAsync
 public class AsyncExecutorConfig extends AsyncConfigurerSupport {
 
+  @Value("${nfvo.vmanager.executor.maxpoolsize:-1}")
+  private int maxPoolSize;
+
+  @Value("${nfvo.vmanager.executor.corepoolsize:1}")
+  private int corePoolSize;
+
+  @Value("${nfvo.vmanager.executor.queuecapacity:0}")
+  private int queueCapacity;
+
+  @Value("${nfvo.vmanager.executor.keepalive:60}")
+  private int keepAliveSeconds;
+
   @Override
+  @Bean
   public Executor getAsyncExecutor() {
+    if (maxPoolSize < 0) maxPoolSize = Integer.MAX_VALUE;
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(1);
-    executor.setQueueCapacity(0);
+    executor.setCorePoolSize(corePoolSize);
+    executor.setQueueCapacity(queueCapacity);
+    executor.setMaxPoolSize(maxPoolSize);
+    executor.setKeepAliveSeconds(keepAliveSeconds);
     executor.setThreadNamePrefix("OpenBatonAsyncTask-");
     executor.initialize();
     return executor;
+  }
+
+  public int getMaxPoolSize() {
+    return maxPoolSize;
+  }
+
+  public void setMaxPoolSize(int maxPoolSize) {
+    this.maxPoolSize = maxPoolSize;
+  }
+
+  public int getCorePoolSize() {
+    return corePoolSize;
+  }
+
+  public void setCorePoolSize(int corePoolSize) {
+    this.corePoolSize = corePoolSize;
+  }
+
+  public int getQueueCapacity() {
+    return queueCapacity;
+  }
+
+  public void setQueueCapacity(int queueCapacity) {
+    this.queueCapacity = queueCapacity;
+  }
+
+  public int getKeepAliveSeconds() {
+    return keepAliveSeconds;
+  }
+
+  public void setKeepAliveSeconds(int keepAliveSeconds) {
+    this.keepAliveSeconds = keepAliveSeconds;
   }
 }

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/VnfmManager.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/VnfmManager.java
@@ -156,7 +156,7 @@ public class VnfmManager
       log.debug(
           "Parameter ordered set to "
               + ordered
-              + ".Consider changing it directly into the openbaton.properties file");
+              + ". Consider changing it directly in the openbaton.properties file.");
       if (ordered) {
         vnfrNames.put(networkServiceRecord.getId(), new HashMap<String, Integer>());
         Map<String, Integer> vnfrNamesWeighted = vnfrNames.get(networkServiceRecord.getId());

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/impl/receiver/RabbitVnfmReceiver.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/impl/receiver/RabbitVnfmReceiver.java
@@ -46,8 +46,8 @@ public class RabbitVnfmReceiver implements VnfmReceiver {
     log.debug("NFVO - core module received (via MB): " + message.getAction());
 
     log.debug("----------Executing ACTION: " + message.getAction());
-    Future<String> res = stateHandler.executeAction(message);
-    String result = res.get();
+    Future<NFVMessage> res = stateHandler.executeAction(message);
+    String result = gson.toJson(res.get());
     log.debug("-----------Finished ACTION: " + message.getAction());
 
     return result;
@@ -61,7 +61,7 @@ public class RabbitVnfmReceiver implements VnfmReceiver {
     log.debug("NFVO - core module received (via MB)" + message.getAction());
 
     log.debug("----------Executing ACTION: " + message.getAction());
-    stateHandler.executeAction(message);
+    stateHandler.executeAction(message).get();
     log.debug("-----------Finished ACTION: " + message.getAction());
   }
 }

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/impl/receiver/VnfmReceiverRest.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/impl/receiver/VnfmReceiverRest.java
@@ -20,6 +20,7 @@ package org.openbaton.nfvo.vnfm_reg.impl.receiver;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import org.openbaton.catalogue.mano.record.VirtualNetworkFunctionRecord;
 import org.openbaton.catalogue.nfvo.messages.Interfaces.NFVMessage;
 import org.openbaton.catalogue.nfvo.messages.OrVnfmGenericMessage;
@@ -64,8 +65,9 @@ public class VnfmReceiverRest implements VnfmReceiver {
     log.debug("NFVO - core module received (via REST): " + nfvMessage);
     NFVMessage message = gson.fromJson(nfvMessage, NFVMessage.class);
 
-    //    return "{}";
-    return vnfStateHandler.executeAction(message).get();
+    Future<NFVMessage> res = vnfStateHandler.executeAction(message);
+    String result = gson.toJson(res.get());
+    return result;
   }
 
   @RequestMapping(
@@ -98,7 +100,7 @@ public class VnfmReceiverRest implements VnfmReceiver {
       throws NotFoundException, VimException, ExecutionException, InterruptedException {
     log.debug("NFVO - core module received (via REST): " + nfvMessage);
     NFVMessage message = gson.fromJson(nfvMessage, NFVMessage.class);
-    vnfStateHandler.executeAction(message);
+    vnfStateHandler.executeAction(message).get();
   }
 
   @RequestMapping(
@@ -113,8 +115,7 @@ public class VnfmReceiverRest implements VnfmReceiver {
 
     log.debug("NFVO - core module received (via REST):" + message);
 
-    return this.gson.fromJson(
-        vnfStateHandler.executeAction(message).get(), OrVnfmGrantLifecycleOperationMessage.class);
+    return (OrVnfmGrantLifecycleOperationMessage) vnfStateHandler.executeAction(message).get();
   }
 
   @RequestMapping(
@@ -127,7 +128,7 @@ public class VnfmReceiverRest implements VnfmReceiver {
   public NFVMessage allocate(@RequestBody VnfmOrAllocateResourcesMessage message)
       throws VimException, ExecutionException, InterruptedException {
 
-    return gson.fromJson(vnfStateHandler.executeAction(message).get(), OrVnfmGenericMessage.class);
+    return (OrVnfmGenericMessage) vnfStateHandler.executeAction(message).get();
   }
 
   @RequestMapping(
@@ -139,8 +140,7 @@ public class VnfmReceiverRest implements VnfmReceiver {
   @ResponseStatus(HttpStatus.ACCEPTED)
   public NFVMessage scale(@RequestBody VnfmOrScalingMessage message)
       throws InterruptedException, ExecutionException, VimException, NotFoundException {
-    return gson.fromJson(vnfStateHandler.executeAction(message).get(), OrVnfmGenericMessage.class);
-    //    return gson.fromJson("{}", OrVnfmGenericMessage.class);
+    return (OrVnfmGenericMessage) vnfStateHandler.executeAction(message).get();
   }
 
   private VirtualNetworkFunctionRecord saveVirtualNetworkFunctionRecord(

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/state/VnfStateHandler.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/state/VnfStateHandler.java
@@ -1,11 +1,9 @@
 package org.openbaton.nfvo.vnfm_reg.state;
 
-import com.google.gson.Gson;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import javax.annotation.PostConstruct;
 import org.openbaton.catalogue.api.DeployNSRBody;
 import org.openbaton.catalogue.mano.descriptor.NetworkServiceDescriptor;
 import org.openbaton.catalogue.mano.descriptor.VirtualDeploymentUnit;
@@ -27,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
@@ -48,80 +45,10 @@ public class VnfStateHandler implements org.openbaton.vnfm.interfaces.state.VnfS
   @Autowired private NetworkServiceDescriptorRepository nsdRepository;
   @Autowired private VnfPackageRepository vnfPackageRepository;
 
-  private ThreadPoolTaskExecutor asyncExecutor;
-
-  @Value("${nfvo.vmanager.executor.maxpoolsize:30}")
-  private int maxPoolSize;
-
-  @Value("${nfvo.vmanager.executor.corepoolsize:5}")
-  private int corePoolSize;
-
-  @Value("${nfvo.vmanager.executor.queuecapacity:100}")
-  private int queueCapacity;
-
-  @Value("${nfvo.vmanager.executor.keepalive:20}")
-  private int keepAliveSeconds;
-
-  @Autowired private Gson gson;
-
-  public int getCorePoolSize() {
-    return corePoolSize;
-  }
-
-  public void setCorePoolSize(int corePoolSize) {
-    this.corePoolSize = corePoolSize;
-  }
-
-  public int getKeepAliveSeconds() {
-    return keepAliveSeconds;
-  }
-
-  public void setKeepAliveSeconds(int keepAliveSeconds) {
-    this.keepAliveSeconds = keepAliveSeconds;
-  }
-
-  public int getQueueCapacity() {
-    return queueCapacity;
-  }
-
-  public void setQueueCapacity(int queueCapacity) {
-    this.queueCapacity = queueCapacity;
-  }
-
-  public int getMaxPoolSize() {
-    return maxPoolSize;
-  }
-
-  public void setMaxPoolSize(int maxPoolSize) {
-    this.maxPoolSize = maxPoolSize;
-  }
-
-  @PostConstruct
-  public void init() {
-
-    /** Asynchronous thread executor configuration */
-    this.asyncExecutor = new ThreadPoolTaskExecutor();
-    this.asyncExecutor.setThreadNamePrefix("OpenbatonTask-");
-    this.asyncExecutor.setMaxPoolSize(maxPoolSize);
-    this.asyncExecutor.setCorePoolSize(corePoolSize);
-    this.asyncExecutor.setQueueCapacity(queueCapacity);
-    this.asyncExecutor.setKeepAliveSeconds(keepAliveSeconds);
-    this.asyncExecutor.initialize();
-
-    log.debug("AsyncExecutor is: " + asyncExecutor);
-
-    log.trace("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-    log.trace("ThreadPollTaskExecutor configuration:");
-    log.trace("MaxPoolSize = " + this.asyncExecutor.getMaxPoolSize());
-    log.trace("CorePoolSize = " + this.asyncExecutor.getCorePoolSize());
-    log.trace("QueueCapacity = " + this.asyncExecutor.getThreadPoolExecutor().getQueue().size());
-    log.trace("KeepAlive = " + this.asyncExecutor.getKeepAliveSeconds());
-    log.trace("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-  }
+  @Autowired private ThreadPoolTaskExecutor asyncExecutor;
 
   @Override
-  @Async
-  public Future<Void> handleVNF(
+  public void handleVNF(
       NetworkServiceDescriptor networkServiceDescriptor,
       NetworkServiceRecord networkServiceRecord,
       DeployNSRBody body,
@@ -142,7 +69,6 @@ public class VnfStateHandler implements org.openbaton.vnfm.interfaces.state.VnfS
     log.debug("----------Executing ACTION: " + message.getAction());
     executeAction(vnfmSender.sendCommand(message, endpoint));
     log.info("Sent " + message.getAction() + " to VNF: " + vnfd.getName());
-    return new AsyncResult<>(null);
   }
 
   private void newExecuteAction(NFVMessage nfvMessage) {}
@@ -161,15 +87,20 @@ public class VnfStateHandler implements org.openbaton.vnfm.interfaces.state.VnfS
 
   @Override
   @Async
-  public Future<String> executeAction(Future<NFVMessage> nfvMessageFuture)
+  public Future<NFVMessage> executeAction(Future<NFVMessage> nfvMessageFuture)
       throws ExecutionException, InterruptedException {
     NFVMessage nfvMessage = nfvMessageFuture.get();
-    return executeAction(nfvMessage);
+    return executeActionNotAsync(nfvMessage);
   }
 
   @Override
   @Async
-  public Future<String> executeAction(NFVMessage nfvMessage)
+  public Future<NFVMessage> executeAction(NFVMessage nfvMessage)
+      throws ExecutionException, InterruptedException {
+    return executeActionNotAsync(nfvMessage);
+  }
+
+  private Future<NFVMessage> executeActionNotAsync(NFVMessage nfvMessage)
       throws ExecutionException, InterruptedException {
     //    log.debug("-----------Finished ACTION: " + nfvMessage.getAction());
     String actionName = nfvMessage.getAction().toString().replace("_", "").toLowerCase();
@@ -211,10 +142,11 @@ public class VnfStateHandler implements org.openbaton.vnfm.interfaces.state.VnfS
               + ". Cyclic="
               + virtualNetworkFunctionRecord.hasCyclicDependency());
     }
-    log.trace("AsyncExecutor is: " + asyncExecutor);
+    log.trace("AsyncExecutor pool size: " + asyncExecutor.getPoolSize());
+    log.trace("AsyncExecutor active count: " + asyncExecutor.getActiveCount());
 
     if (isaReturningTask(nfvMessage.getAction())) {
-      return new AsyncResult<>(gson.toJson(asyncExecutor.submit(task).get()));
+      return asyncExecutor.submit(task);
     } else {
       asyncExecutor.submit(task);
       return null;

--- a/vnfm/vnfm-int/src/main/java/org/openbaton/vnfm/interfaces/state/VnfStateHandler.java
+++ b/vnfm/vnfm-int/src/main/java/org/openbaton/vnfm/interfaces/state/VnfStateHandler.java
@@ -16,7 +16,7 @@ import org.springframework.scheduling.annotation.Async;
 
 /** Created by lto on 29.05.17. */
 public interface VnfStateHandler {
-  Future<Void> handleVNF(
+  void handleVNF(
       NetworkServiceDescriptor networkServiceDescriptor,
       NetworkServiceRecord networkServiceRecord,
       DeployNSRBody body,
@@ -25,11 +25,11 @@ public interface VnfStateHandler {
       throws NotFoundException, BadFormatException, ExecutionException, InterruptedException;
 
   @Async
-  Future<String> executeAction(Future<NFVMessage> nfvMessage)
+  Future<NFVMessage> executeAction(Future<NFVMessage> nfvMessage)
       throws ExecutionException, InterruptedException;
 
   @Async
-  Future<String> executeAction(NFVMessage nfvMessage)
+  Future<NFVMessage> executeAction(NFVMessage nfvMessage)
       throws ExecutionException, InterruptedException;
 
   void terminate(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord);


### PR DESCRIPTION
Reason for the deadlock was the threadpool. Now the default configuration does not limit the thread pool's size. If other values are set for corepoolsize and queuecapacity, a deadlock can occur again. Some changes were made to the VNFStateHandler and related components in order to reduce the number of started threads (without losing the concurrent execution).