### PR TITLE
fix: tosca parser works with new spring; better error messages; updat…

### DIFF
--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/VNFPackageManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/VNFPackageManagement.java
@@ -717,7 +717,8 @@ public class VNFPackageManagement
       vnfPackage.setScriptsLink((String) metadata.get("scripts-link"));
     }
     if (metadata.containsKey("vim_types")) {
-      Set<String> vimTypes = (Set<String>) metadata.get("vim_types");
+      LinkedHashSet<String> vimTypes = new LinkedHashSet<>();
+      vimTypes.addAll((ArrayList) metadata.get("vim_types"));
       vnfPackage.setVimTypes(vimTypes);
     } else {
       log.warn("vim_types is not specified! it is not possible to check the vim");

--- a/tosca-parser/build.gradle
+++ b/tosca-parser/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile project(':repository')
     compile project(":core-impl")
 
-    compile 'org.yaml:snakeyaml:1.17'
+    compile 'org.yaml:snakeyaml:1.19'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'commons-io:commons-io:2.5'
     compile 'org.springframework.boot:spring-boot-starter-amqp'

--- a/tosca-parser/src/main/java/org/openbaton/tosca/parser/TOSCAParser.java
+++ b/tosca-parser/src/main/java/org/openbaton/tosca/parser/TOSCAParser.java
@@ -196,6 +196,8 @@ public class TOSCAParser {
       }
     }
 
+    virtualLinkReferences.addAll(vnf.getRequirements().getVirtualLinks());
+
     // ADD VLs
     //ArrayList<String> vl_list = vnf.getRequirements().getVirtualLinks();
     Set<InternalVirtualLink> vls = new HashSet<>();

--- a/tosca-parser/src/main/java/org/openbaton/tosca/templates/TopologyTemplate/TopologyTemplate.java
+++ b/tosca-parser/src/main/java/org/openbaton/tosca/templates/TopologyTemplate/TopologyTemplate.java
@@ -57,7 +57,7 @@ public class TopologyTemplate {
     for (String nodeName : node_templates.keySet()) {
 
       NodeTemplate n = node_templates.get(nodeName);
-      if (Objects.equals(n.getType(), "tosca.nodes.nfv.CP")) {
+      if (Objects.equals(n.getType().toLowerCase(), "tosca.nodes.nfv.cp")) {
 
         CPNodeTemplate cpNode = new CPNodeTemplate(n);
         cpNodes.add(cpNode);
@@ -73,7 +73,7 @@ public class TopologyTemplate {
     for (String nodeName : node_templates.keySet()) {
 
       NodeTemplate n = node_templates.get(nodeName);
-      if (Objects.equals(n.getType(), "tosca.nodes.nfv.VDU")) {
+      if (Objects.equals(n.getType().toLowerCase(), "tosca.nodes.nfv.vdu")) {
 
         VDUNodeTemplate vduNode = new VDUNodeTemplate(n, nodeName);
         vduNodes.add(vduNode);
@@ -90,7 +90,7 @@ public class TopologyTemplate {
     for (String nodeName : node_templates.keySet()) {
 
       NodeTemplate n = node_templates.get(nodeName);
-      if (Objects.equals(n.getType(), "tosca.nodes.nfv.VL")) {
+      if (Objects.equals(n.getType().toLowerCase(), "tosca.nodes.nfv.vl")) {
         VLNodeTemplate vduNode = new VLNodeTemplate(n, nodeName);
         vlNodes.add(vduNode);
       }
@@ -106,7 +106,7 @@ public class TopologyTemplate {
     for (String nodeName : node_templates.keySet()) {
 
       NodeTemplate n = node_templates.get(nodeName);
-      if (Objects.equals(n.getType(), "openbaton.type.VNF")) {
+      if (Objects.equals(n.getType().toLowerCase(), "openbaton.type.vnf")) {
 
         VNFNodeTemplate vnfNode = new VNFNodeTemplate(n, nodeName);
         vnfNodes.add(vnfNode);

--- a/tosca-parser/src/main/java/org/openbaton/utils/Utils.java
+++ b/tosca-parser/src/main/java/org/openbaton/utils/Utils.java
@@ -19,14 +19,19 @@ package org.openbaton.utils;
 
 import java.io.*;
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.openbaton.exceptions.BadFormatException;
 import org.openbaton.tosca.templates.NSDTemplate;
 import org.openbaton.tosca.templates.VNFDTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
 /** Created by dbo on 31/01/16. */
 public final class Utils {
+
+  private static final Logger log = LoggerFactory.getLogger(Utils.class);
 
   public static void copy(InputStream in, OutputStream out) throws IOException {
     byte[] buffer = new byte[1024];
@@ -73,7 +78,7 @@ public final class Utils {
     return yaml.loadAs(new ByteArrayInputStream(b.toByteArray()), VNFDTemplate.class);
   }
 
-  public static NSDTemplate bytesToNSDTemplate(ByteArrayOutputStream b) {
+  public static NSDTemplate bytesToNSDTemplate(ByteArrayOutputStream b) throws BadFormatException {
 
     Constructor constructor = new Constructor(NSDTemplate.class);
     TypeDescription projectDesc = new TypeDescription(NSDTemplate.class);
@@ -81,6 +86,12 @@ public final class Utils {
     constructor.addTypeDescription(projectDesc);
 
     Yaml yaml = new Yaml(constructor);
-    return yaml.loadAs(new ByteArrayInputStream(b.toByteArray()), NSDTemplate.class);
+    try {
+      return yaml.loadAs(new ByteArrayInputStream(b.toByteArray()), NSDTemplate.class);
+    } catch (Exception e) {
+      log.error(e.getLocalizedMessage());
+      throw new BadFormatException(
+          "Problem parsing the descriptor. Check if yaml is formatted correctly.");
+    }
   }
 }

--- a/tosca-parser/src/main/resources/types.yaml
+++ b/tosca-parser/src/main/resources/types.yaml
@@ -1,0 +1,60 @@
+##################################################################################
+#
+# Here we define all of the high level types
+#
+##################################################################################
+
+node_types:
+
+
+  openbaton.type.VNF:
+    properties:
+      vendor:
+        type: string
+      version:
+        type: string
+      endpoint:
+        type: string
+      vnfPackageLocation:
+        type: string
+      type:
+        type: string
+      deploymentFlavour:
+        type: list
+      configurations:
+        type: {}
+    requirements:
+      type: list
+    interfaces:
+      type: {}
+
+
+  tosca.nodes.nfv.VDU:
+    properties:
+      scale_in_out:
+        type: int
+      vim_instance_name:
+        type: list
+    artifacts:
+      type: {}
+
+  tosca.nodes.nfv.CP:
+    properties:
+      floatingIP:
+        type: string
+    requirements:
+      type: list
+
+  tosca.nodes.nfv.VL:
+    properties:
+      vendor:
+        type: string
+
+
+  tosca.nodes.relationships.ConnectsTo:
+    source:
+      type: string
+    target:
+      type: string
+    parameters:
+      type: list


### PR DESCRIPTION
The tosca parser is now compatible with new spring versions. I also updated the yaml parser (snake-yaml) to the newest version. The error messages when the yaml is not well formatted are better, but not perfect. Fixed the way the csar is read and other small changes that should improve usability. 
I tested onboarding and launching: 
1) Test csar from docs
2) Iperf csar from docs
3) openims from market 