### PR TITLE
fix: tentative to upgrade schema by flyway

### DIFF
--- a/main/src/main/java/org/openbaton/nfvo/system/FlywayConfig.java
+++ b/main/src/main/java/org/openbaton/nfvo/system/FlywayConfig.java
@@ -61,16 +61,6 @@ class schema_version implements Serializable {
 
   private String version;
 
-  public int getVersion_rank() {
-    return version_rank;
-  }
-
-  public void setVersion_rank(int version_rank) {
-    this.version_rank = version_rank;
-  }
-
-  private int version_rank;
-
   private String description;
 
   private String type;


### PR DESCRIPTION
If Flyway (4.x) finds version_rank in the schema_version table it tries
to upgrade and it fails.