### PR TITLE
Fix: Set project ID of VNFD before checking its integrity

### DIFF
--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/VNFPackageManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/VNFPackageManagement.java
@@ -249,6 +249,8 @@ public class VNFPackageManagement
         handleVnfPackageMetadata(
             metadata, vnfPackage, virtualNetworkFunctionDescriptor.getEndpoint(), projectId, "tar");
 
+    virtualNetworkFunctionDescriptor.setProjectId(projectId);
+
     nsdUtils.fetchVimInstances(virtualNetworkFunctionDescriptor, projectId);
     nsdUtils.checkIntegrity(virtualNetworkFunctionDescriptor);
 
@@ -265,7 +267,6 @@ public class VNFPackageManagement
 
     vnfPackage.setImage(image);
 
-    virtualNetworkFunctionDescriptor.setProjectId(projectId);
     vnfPackage.setProjectId(projectId);
     // check if package already exists
 


### PR DESCRIPTION
Otherwise the checkIntegrity method could not retrieve the VIMs of the project.