### PR TITLE
Issue 280

### DIFF
--- a/catalogue/src/main/java/org/openbaton/catalogue/mano/common/NetworkIps.java
+++ b/catalogue/src/main/java/org/openbaton/catalogue/mano/common/NetworkIps.java
@@ -53,9 +53,9 @@ public class NetworkIps extends BaseEntity {
     for (SubnetIp subnetIp : subnetIps) {
       retVal +=
           "{'"
-              + subnetIp.getSubnetName()
-              + "', '"
               + subnetIp.getIp()
+              + "', '"
+              + subnetIp.getSubnetName()
               + "', '"
               + subnetIp.getInterfaceId()
               + "'}";

--- a/catalogue/src/main/java/org/openbaton/catalogue/mano/common/NetworkIps.java
+++ b/catalogue/src/main/java/org/openbaton/catalogue/mano/common/NetworkIps.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016 Open Baton (http://www.openbaton.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.openbaton.catalogue.mano.common;
+
+import java.util.Set;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import org.openbaton.catalogue.util.BaseEntity;
+
+/** Created by ruthd on 02/03/18. */
+@Entity
+public class NetworkIps extends BaseEntity {
+  private String netName;
+
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  private Set<SubnetIp> subnetIps;
+
+  public Set<SubnetIp> getSubnetIps() {
+    return subnetIps;
+  }
+
+  public void setSubnetIps(Set<SubnetIp> subnetIps) {
+    this.subnetIps = subnetIps;
+  }
+
+  public String getNetName() {
+    return netName;
+  }
+
+  public void setNetName(String netName) {
+    this.netName = netName;
+  }
+
+  public String printSubnetIps() {
+    String retVal = "";
+    for (SubnetIp subnetIp : subnetIps) {
+      retVal +=
+          "{'"
+              + subnetIp.getSubnetName()
+              + "', '"
+              + subnetIp.getIp()
+              + "', '"
+              + subnetIp.getInterfaceId()
+              + "'}";
+    }
+    return retVal;
+  }
+
+  @Override
+  public String toString() {
+    String retVal = "NetworkIps{" + "netName='" + netName + "\'";
+
+    for (SubnetIp subnetIp : subnetIps) {
+      retVal += ", " + subnetIp;
+    }
+    retVal += "} " + super.toString();
+    return retVal;
+  }
+}

--- a/catalogue/src/main/java/org/openbaton/catalogue/mano/common/SubnetIp.java
+++ b/catalogue/src/main/java/org/openbaton/catalogue/mano/common/SubnetIp.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016 Open Baton (http://www.openbaton.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.openbaton.catalogue.mano.common;
+
+import javax.persistence.Entity;
+import org.openbaton.catalogue.util.BaseEntity;
+
+/** Created by ruthd on 02/03/18. */
+@Entity
+public class SubnetIp extends BaseEntity {
+
+  // There can be more than one instance of SubnetIp with the same subnet name associated with a single server on
+  // a single network.  (NOTE: in aws the subnetName is empty)
+  private String subnetName;
+  private String ip;
+  // The interfaceId will be the interface id from the vnfd.json file if provided (0 - n), otherwise it will be empty
+  private String interfaceId = "";
+
+  public String getIp() {
+    return ip;
+  }
+
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  public String getSubnetName() {
+    return subnetName;
+  }
+
+  public void setSubnetName(String subnetName) {
+    this.subnetName = subnetName;
+  }
+
+  public String getInterfaceId() {
+    return interfaceId;
+  }
+
+  public void setInterfaceId(String interfaceId) {
+    this.interfaceId = interfaceId;
+  }
+
+  @Override
+  public String toString() {
+    return "SubnetIp{"
+        + "subnetName='"
+        + subnetName
+        + '\''
+        + ", ip='"
+        + ip
+        + '\''
+        + ", interfaceId='"
+        + interfaceId
+        + '\''
+        + "} "
+        + super.toString();
+  }
+}

--- a/catalogue/src/main/java/org/openbaton/catalogue/mano/record/VNFCInstance.java
+++ b/catalogue/src/main/java/org/openbaton/catalogue/mano/record/VNFCInstance.java
@@ -45,8 +45,12 @@ public class VNFCInstance extends VNFComponent {
   @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<Ip> floatingIps;
 
+  @Deprecated
   @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
-  private Set<NetworkIps> ips;
+  private Set<Ip> ips;
+
+  @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+  private Set<NetworkIps> fixedIps;
 
   public String getHostname() {
     return hostname;
@@ -121,11 +125,21 @@ public class VNFCInstance extends VNFComponent {
     this.floatingIps = floatingIps;
   }
 
-  public Set<NetworkIps> getIps() {
+  @Deprecated
+  public Set<Ip> getIps() {
     return ips;
   }
 
-  public void setIps(Set<NetworkIps> ips) {
+  @Deprecated
+  public void setIps(Set<Ip> ips) {
     this.ips = ips;
+  }
+
+  public Set<NetworkIps> getFixedIps() {
+    return fixedIps;
+  }
+
+  public void setFixedIps(Set<NetworkIps> fixedIps) {
+    this.fixedIps = fixedIps;
   }
 }

--- a/catalogue/src/main/java/org/openbaton/catalogue/mano/record/VNFCInstance.java
+++ b/catalogue/src/main/java/org/openbaton/catalogue/mano/record/VNFCInstance.java
@@ -24,6 +24,7 @@ import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import org.openbaton.catalogue.mano.common.Ip;
+import org.openbaton.catalogue.mano.common.NetworkIps;
 import org.openbaton.catalogue.mano.descriptor.VNFComponent;
 
 /** Created by lto on 08/09/15. */
@@ -45,7 +46,7 @@ public class VNFCInstance extends VNFComponent {
   private Set<Ip> floatingIps;
 
   @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
-  private Set<Ip> ips;
+  private Set<NetworkIps> ips;
 
   public String getHostname() {
     return hostname;
@@ -120,11 +121,11 @@ public class VNFCInstance extends VNFComponent {
     this.floatingIps = floatingIps;
   }
 
-  public Set<Ip> getIps() {
+  public Set<NetworkIps> getIps() {
     return ips;
   }
 
-  public void setIps(Set<Ip> ips) {
+  public void setIps(Set<NetworkIps> ips) {
     this.ips = ips;
   }
 }

--- a/catalogue/src/main/java/org/openbaton/catalogue/nfvo/Server.java
+++ b/catalogue/src/main/java/org/openbaton/catalogue/nfvo/Server.java
@@ -19,9 +19,10 @@ package org.openbaton.catalogue.nfvo;
 
 import java.io.Serializable;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.openbaton.catalogue.mano.common.DeploymentFlavour;
+import org.openbaton.catalogue.mano.common.SubnetIp;
 import org.openbaton.catalogue.nfvo.images.NFVImage;
 
 public class Server implements Serializable {
@@ -34,7 +35,7 @@ public class Server implements Serializable {
   private String extendedStatus;
   private String extId;
 
-  private Map<String, List<String>> ips;
+  private Map<String, Set<SubnetIp>> ips;
 
   private Map<String, String> floatingIps;
 
@@ -69,11 +70,11 @@ public class Server implements Serializable {
     this.extId = extId;
   }
 
-  public Map<String, List<String>> getIps() {
+  public Map<String, Set<SubnetIp>> getIps() {
     return ips;
   }
 
-  public void setIps(Map<String, List<String>> ips) {
+  public void setIps(Map<String, Set<SubnetIp>> ips) {
     this.ips = ips;
   }
 

--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
@@ -33,7 +33,8 @@ import java.util.regex.Pattern;
 import javax.persistence.EntityManager;
 import org.openbaton.catalogue.api.DeployNSRBody;
 import org.openbaton.catalogue.mano.common.DeploymentFlavour;
-import org.openbaton.catalogue.mano.common.Ip;
+import org.openbaton.catalogue.mano.common.NetworkIps;
+import org.openbaton.catalogue.mano.common.SubnetIp;
 import org.openbaton.catalogue.mano.descriptor.*;
 import org.openbaton.catalogue.mano.record.*;
 import org.openbaton.catalogue.nfvo.*;
@@ -962,8 +963,10 @@ public class NetworkServiceRecordManagement
     }
 
     resourceManagement.release(virtualDeploymentUnit, vnfcInstance);
-    for (Ip ip : vnfcInstance.getIps()) {
-      virtualNetworkFunctionRecord.getVnf_address().remove(ip.getIp());
+    for (NetworkIps networkIps : vnfcInstance.getIps()) {
+      for (SubnetIp subnetIp : networkIps.getSubnetIps()) {
+        virtualNetworkFunctionRecord.getVnf_address().remove(subnetIp.getIp());
+      }
     }
     virtualDeploymentUnit.getVnfc().remove(vnfcInstance.getVnfComponent());
     virtualDeploymentUnit.getVnfc_instance().remove(vnfcInstance);

--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/api/NetworkServiceRecordManagement.java
@@ -963,7 +963,7 @@ public class NetworkServiceRecordManagement
     }
 
     resourceManagement.release(virtualDeploymentUnit, vnfcInstance);
-    for (NetworkIps networkIps : vnfcInstance.getIps()) {
+    for (NetworkIps networkIps : vnfcInstance.getFixedIps()) {
       for (SubnetIp subnetIp : networkIps.getSubnetIps()) {
         virtualNetworkFunctionRecord.getVnf_address().remove(subnetIp.getIp());
       }

--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/core/DependencyManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/core/DependencyManagement.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import javax.persistence.NoResultException;
 import org.hibernate.StaleObjectStateException;
 import org.openbaton.catalogue.mano.common.Ip;
+import org.openbaton.catalogue.mano.common.NetworkIps;
 import org.openbaton.catalogue.mano.descriptor.VirtualDeploymentUnit;
 import org.openbaton.catalogue.mano.record.NetworkServiceRecord;
 import org.openbaton.catalogue.mano.record.Status;
@@ -222,20 +223,35 @@ public class DependencyManagement
           }
           vnfcDependencyParameters.getParameters().put(vnfcInstance.getId(), dependencyParameters);
         }
-        for (Ip ip : vnfcInstance.getIps()) {
-          if (parameterKeys.contains(ip.getNetName())) {
+        for (NetworkIps networkIps : vnfcInstance.getIps()) {
+          if (parameterKeys.contains(networkIps.getNetName())) {
             log.debug(
                 "Adding "
-                    + ip.getNetName()
+                    + networkIps.getNetName()
                     + "="
-                    + ip.getIp()
+                    + networkIps.getSubnetIps().iterator().next().getIp()
                     + ". VNFCInstance ID: "
                     + vnfcInstance.getId());
             vnfcDependencyParameters
                 .getParameters()
                 .get(vnfcInstance.getId())
                 .getParameters()
-                .put(ip.getNetName(), ip.getIp());
+                .put(networkIps.getNetName(), networkIps.getSubnetIps().iterator().next().getIp());
+          }
+          if (parameterKeys.contains(networkIps.getNetName() + "_ips")) {
+            log.debug(
+                "Adding "
+                    + networkIps.getNetName()
+                    + "_set"
+                    + "="
+                    + networkIps.printSubnetIps()
+                    + ". VNFCInstance ID: "
+                    + vnfcInstance.getId());
+            vnfcDependencyParameters
+                .getParameters()
+                .get(vnfcInstance.getId())
+                .getParameters()
+                .put(networkIps.getNetName() + "_ips", networkIps.printSubnetIps());
           }
         }
 

--- a/core/core-impl/src/main/java/org/openbaton/nfvo/core/core/DependencyManagement.java
+++ b/core/core-impl/src/main/java/org/openbaton/nfvo/core/core/DependencyManagement.java
@@ -223,7 +223,7 @@ public class DependencyManagement
           }
           vnfcDependencyParameters.getParameters().put(vnfcInstance.getId(), dependencyParameters);
         }
-        for (NetworkIps networkIps : vnfcInstance.getIps()) {
+        for (NetworkIps networkIps : vnfcInstance.getFixedIps()) {
           if (parameterKeys.contains(networkIps.getNetName())) {
             log.debug(
                 "Adding "

--- a/vim-impl/src/main/java/org/openbaton/vim_impl/vim/GenericVIM.java
+++ b/vim-impl/src/main/java/org/openbaton/vim_impl/vim/GenericVIM.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import org.openbaton.catalogue.mano.common.DeploymentFlavour;
 import org.openbaton.catalogue.mano.common.Ip;
+import org.openbaton.catalogue.mano.common.NetworkIps;
+import org.openbaton.catalogue.mano.common.SubnetIp;
 import org.openbaton.catalogue.mano.descriptor.VNFComponent;
 import org.openbaton.catalogue.mano.descriptor.VNFDConnectionPoint;
 import org.openbaton.catalogue.mano.descriptor.VirtualDeploymentUnit;
@@ -1571,13 +1573,17 @@ public class GenericVIM extends Vim {
       }
     }
 
-    for (Entry<String, List<String>> network : server.getIps().entrySet()) {
-      Ip ip = new Ip();
-      ip.setNetName(network.getKey());
-      ip.setIp(network.getValue().iterator().next());
-      vnfcInstance.getIps().add(ip);
-      for (String ip1 : server.getIps().get(network.getKey())) {
-        vnfr.getVnf_address().add(ip1);
+    for (Entry<String, Set<SubnetIp>> network : server.getIps().entrySet()) {
+      NetworkIps networkIps = new NetworkIps();
+      networkIps.setNetName(network.getKey());
+      networkIps.setSubnetIps(new HashSet<>());
+      for (SubnetIp subnetIp : network.getValue()) {
+        networkIps.getSubnetIps().add(subnetIp);
+      }
+
+      vnfcInstance.getIps().add(networkIps);
+      for (SubnetIp ip : server.getIps().get(network.getKey())) {
+        vnfr.getVnf_address().add(ip.getIp());
       }
     }
     return vnfcInstance;

--- a/vim-impl/src/main/java/org/openbaton/vim_impl/vim/GenericVIM.java
+++ b/vim-impl/src/main/java/org/openbaton/vim_impl/vim/GenericVIM.java
@@ -1478,7 +1478,7 @@ public class GenericVIM extends Vim {
             vnfcInstance.setVnfComponent(vnfComponent);
             vnfcInstance.setVc_id("unknown");
             vnfcInstance.setState("ERROR");
-            vnfcInstance.setIps(new HashSet<>());
+            vnfcInstance.setFixedIps(new HashSet<>());
             vnfcInstance.setFloatingIps(new HashSet<>());
           }
           throw new VimException(
@@ -1561,7 +1561,7 @@ public class GenericVIM extends Vim {
 
     vnfcInstance.setVnfComponent(vnfComponent);
 
-    vnfcInstance.setIps(new HashSet<>());
+    vnfcInstance.setFixedIps(new HashSet<>());
     vnfcInstance.setFloatingIps(new HashSet<>());
 
     if (!floatingIps.isEmpty()) {
@@ -1581,7 +1581,7 @@ public class GenericVIM extends Vim {
         networkIps.getSubnetIps().add(subnetIp);
       }
 
-      vnfcInstance.getIps().add(networkIps);
+      vnfcInstance.getFixedIps().add(networkIps);
       for (SubnetIp ip : server.getIps().get(network.getKey())) {
         vnfr.getVnf_address().add(ip.getIp());
       }
@@ -1597,13 +1597,8 @@ public class GenericVIM extends Vim {
       Server server)
       throws VimException {
     try {
-      if (vnfComponent.getConnection_point().size() != vnfcInstance.getIps().size()) {
-        throw new VimException(
-            "Not all (or too many) internal IPs were associated. Expected: "
-                + vnfComponent.getConnection_point().size()
-                + " Allocated: "
-                + vnfcInstance.getIps().size());
-      }
+      // Since you can have multiple connections to the same network do NOT check the number of networks against
+      // the number of connection points
       int expectedFloatingIpCount = 0;
       for (VNFDConnectionPoint cp : vnfComponent.getConnection_point()) {
         if (cp.getFloatingIp() != null && !cp.getFloatingIp().isEmpty()) {

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/HealTask.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/HealTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import org.openbaton.catalogue.mano.common.Event;
 import org.openbaton.catalogue.mano.common.Ip;
+import org.openbaton.catalogue.mano.common.NetworkIps;
 import org.openbaton.catalogue.mano.descriptor.VirtualDeploymentUnit;
 import org.openbaton.catalogue.mano.record.NetworkServiceRecord;
 import org.openbaton.catalogue.mano.record.Status;
@@ -140,7 +141,12 @@ public class HealTask extends AbstractTask {
       for (Ip ip : vnfcInstance.getFloatingIps())
         vnfcDP.getParameters().put(ip.getNetName() + "_floatingIp", ip.getIp());
 
-      for (Ip ip : vnfcInstance.getIps()) vnfcDP.getParameters().put(ip.getNetName(), ip.getIp());
+      for (NetworkIps networkIps : vnfcInstance.getIps()) {
+        vnfcDP
+            .getParameters()
+            .put(networkIps.getNetName(), networkIps.getSubnetIps().iterator().next().getIp());
+        vnfcDP.getParameters().put(networkIps.getNetName() + "_ips", networkIps.printSubnetIps());
+      }
 
       vnfcDP.getParameters().put("hostname", vnfcInstance.getHostname());
 

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/HealTask.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/HealTask.java
@@ -141,7 +141,7 @@ public class HealTask extends AbstractTask {
       for (Ip ip : vnfcInstance.getFloatingIps())
         vnfcDP.getParameters().put(ip.getNetName() + "_floatingIp", ip.getIp());
 
-      for (NetworkIps networkIps : vnfcInstance.getIps()) {
+      for (NetworkIps networkIps : vnfcInstance.getFixedIps()) {
         vnfcDP
             .getParameters()
             .put(networkIps.getNetName(), networkIps.getSubnetIps().iterator().next().getIp());

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/ScaledTask.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/ScaledTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import org.openbaton.catalogue.mano.common.Event;
 import org.openbaton.catalogue.mano.common.Ip;
+import org.openbaton.catalogue.mano.common.NetworkIps;
 import org.openbaton.catalogue.mano.descriptor.VirtualDeploymentUnit;
 import org.openbaton.catalogue.mano.record.NetworkServiceRecord;
 import org.openbaton.catalogue.mano.record.VNFCInstance;
@@ -176,8 +177,13 @@ public class ScaledTask extends AbstractTask {
             vnfcDP.getParameters().put(ip.getNetName() + "_floatingIp", ip.getIp());
           }
 
-          for (Ip ip : vnfcInstance.getIps()) {
-            vnfcDP.getParameters().put(ip.getNetName(), ip.getIp());
+          for (NetworkIps networkIps : vnfcInstance.getIps()) {
+            vnfcDP
+                .getParameters()
+                .put(networkIps.getNetName(), networkIps.getSubnetIps().iterator().next().getIp());
+            vnfcDP
+                .getParameters()
+                .put(networkIps.getNetName() + "_ips", networkIps.printSubnetIps());
           }
 
           vnfcDP.getParameters().put("hostname", vnfcInstance.getHostname());

--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/ScaledTask.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/ScaledTask.java
@@ -177,7 +177,7 @@ public class ScaledTask extends AbstractTask {
             vnfcDP.getParameters().put(ip.getNetName() + "_floatingIp", ip.getIp());
           }
 
-          for (NetworkIps networkIps : vnfcInstance.getIps()) {
+          for (NetworkIps networkIps : vnfcInstance.getFixedIps()) {
             vnfcDP
                 .getParameters()
                 .put(networkIps.getNetName(), networkIps.getSubnetIps().iterator().next().getIp());


### PR DESCRIPTION
Currently if there is more than one interface (openstack port) on a single network only the first interfaces's IP address is available to the scripts as $network_name. If there is more than one subnet associated with a particular network (i.e. IPv4 and IPv6) openstack assigns IP addresses from both but the value of $network_name in the scripts is randomly assigned between the two.

Update the VNFCInstance to have not only a single ip address per network but now have all ip addresses including their subnets and interface id's if specified in the vnfd.json file.

This references issue #280 .  Changes were also made to other repos that need to be merged.  Relevant pull requests are:

openbaton/openstack4j-plugin#64
openbaton/generic-vnfm#72
openbaton/plugin-vimdriver-amazon#2
openbaton/network-slicing-engine#14
