### PR TITLE
Set ext_id in virtualLinkRecord

### DIFF
--- a/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/GrantoperationTask.java
+++ b/vnfm/vnfm-impl/src/main/java/org/openbaton/nfvo/vnfm_reg/tasks/GrantoperationTask.java
@@ -227,8 +227,10 @@ public class GrantoperationTask extends AbstractTask {
                         "Checking VLR %s for VNFR [%s]",
                         virtualLinkRecord, virtualNetworkFunctionRecord.getName()));
                 for (BaseNetwork net : finalVimInstance1.getNetworks()) {
-                  if (VimInstanceUtils.isVLRExisting(virtualLinkRecord, net, dedicatedNetworks))
+                  if (VimInstanceUtils.isVLRExisting(virtualLinkRecord, net, dedicatedNetworks)) {
+                    virtualLinkRecord.setExtId(net.getExtId());
                     return false;
+                  }
                 }
                 return true;
               })


### PR DESCRIPTION
During instantiation of an instance in docker vnfm, ext_id of VLR was missing. This change sets the ext_id so that docker instantiation runs without error.