### PR TITLE
Enable spring profile mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN ./gradlew clean build -x test
 
 FROM openjdk:8-jre-alpine
 COPY --from=builder /project/build/libs/*.jar /nfvo.jar
-COPY --from=builder /project/main/src/main/resources/application.properties /etc/openbaton/openbaton-nfvo.properties
-ENV NFVO_PLUGIN_INSTALLATION-DIR /usr/lib/openbaton/plugins
-ENTRYPOINT ["java", "-jar", "/nfvo.jar", "--spring.config.location=file:/etc/openbaton/openbaton-nfvo.properties"]
+ENTRYPOINT ["java", "-jar", "/nfvo.jar"]
 EXPOSE 8080
 EXPOSE 8443

--- a/main/src/main/resources/application-mysql.properties
+++ b/main/src/main/resources/application-mysql.properties
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2016 Open Baton (http://www.openbaton.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+# Launch the Application with --spring.profiles.active=mysql to enable this configuration
+
+spring.datasource.username=admin
+spring.datasource.password=changeme
+
+spring.datasource.url=jdbc:mysql://localhost:3306/openbaton?useSSL=false
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=update
+
+spring.datasource.validationQuery=SELECT 1
+spring.datasource.testOnBorrow=true


### PR DESCRIPTION
- Launch the Application with --spring.profiles.active=mysql for using MySQL
- Dockerfile has been cleaned, now only using env variables
Docker compose configuration looks like:
environment:
      - NFVO_RABBIT_BROKERIP=${HOST_IP}
      - SPRING_RABBITMQ_HOST=rabbitmq_broker
      - SPRING_PROFILES_ACTIVE=mysql
      - SPRING_DATASOURCE_URL=jdbc:mysql://nfvo_database:3306/openbaton?useSSL=false