### PR TITLE
Imp: set metadata from vld for dockernetwork vlr

### DIFF
--- a/common/src/main/java/org/openbaton/nfvo/common/utils/viminstance/VimInstanceUtils.java
+++ b/common/src/main/java/org/openbaton/nfvo/common/utils/viminstance/VimInstanceUtils.java
@@ -279,6 +279,7 @@ public class VimInstanceUtils {
       return network;
     } else if (vimInstance instanceof DockerVimInstance) {
       DockerNetwork networkdc = new DockerNetwork();
+      networkdc.setMetadata(getMetadataFromVLName(vlr.getName(), networkServiceDescriptor));
       networkdc.setName(vlr.getName());
       networkdc.setSubnet(
           getCidrFromVLName(
@@ -289,6 +290,17 @@ public class VimInstanceUtils {
       networkb.setName(vlr.getName());
       return networkb;
     }
+  }
+
+  private static Map<String, String> getMetadataFromVLName(
+      String virtual_link_reference,
+      NetworkServiceDescriptor networkServiceDescriptor) {
+    for (VirtualLinkDescriptor vld : networkServiceDescriptor.getVld()) {
+      if (vld.getName().equals(virtual_link_reference)) {
+        return vld.getMetadata();
+      }
+    }
+    return new HashMap<>();
   }
 
   private static String getCidrFromVLName(


### PR DESCRIPTION
Extends the docker network creation to include any set metadata in the vld, e.g.
```json
"vld":[
  {
    "name":"vpp_net",
    "cidr": "192.168.1.0\/24",
    "metadata": {"driver": "vpp",
    "ipam-driver": "vpp"}
  }

```
Please advice if I should implement this rather in the base entity than for the specific case

See https://github.com/openbaton/go-docker-driver/pull/2